### PR TITLE
Add a 250 ms debounce to form submission

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013-2014 Aarni Koskela, Santtu Pajukanta
+Copyright (c) 2013-2014 Aarni Koskela, Santtu Pajukanta, Anssi Matti Helin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lippukala/templates/lippukala/pos.html
+++ b/lippukala/templates/lippukala/pos.html
@@ -153,6 +153,17 @@ function syncUseQueue() {
     }
 }
 
+function debounce(fn, delay) {
+    var timer = null;
+    return function() {
+        var clear = function() { timer = null; }
+        if (timer === null) { fn.apply(this, arguments); }
+        else { arguments[0].preventDefault(); }
+        window.clearTimeout(timer);
+        timer = window.setTimeout(clear, delay);
+    };
+}
+
 function init() {
     download();
     setInterval(download, (50 + Math.random() * 20) * 1000);
@@ -161,7 +172,7 @@ function init() {
     codeInput = document.getElementById("code");
     statusDiv = document.getElementById("status");
     codeInput.addEventListener("input", keyPress, true);
-    document.getElementById("codeform").addEventListener("submit", formSubmit, true);
+    document.getElementById("codeform").addEventListener("submit", debounce(formSubmit, 250), true);
 }
 </script>
 <style type="text/css">

--- a/lippukala_test_app/__main__.py
+++ b/lippukala_test_app/__main__.py
@@ -5,6 +5,8 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "lippukala_test_app.settings")
 
 
 def seed():
+    import django
+    django.setup()
     from lippukala_tests.utils import _create_test_order
     for x in range(20):
         print(_create_test_order().pk)


### PR DESCRIPTION
This hopefully prevents some issues encountered with barcode scanners sending double (or more) linefeeds after scanning.

Also a minor fix to run `django.setup()` when seeding data, seems to fix some encountered issues when developing.