### PR TITLE
POS: custom <dialog> 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,11 +3,7 @@ module.exports = {
     browser: true,
     es2021: true,
   },
-  extends: [
-    "eslint:recommended",
-    "eslint-config-airbnb-base",
-    "eslint-config-prettier",
-  ],
+  extends: ["eslint:recommended", "eslint-config-airbnb-base", "eslint-config-prettier"],
   parserOptions: {
     ecmaVersion: "latest",
   },

--- a/lippukala/templates/lippukala/pos.html
+++ b/lippukala/templates/lippukala/pos.html
@@ -69,18 +69,25 @@
       }
 
       /**
-       * @param {Code} code
+       * @param {Code|null} code
        */
       function showCode(code) {
-        currentlyShownId = code.id;
-        $("#status").innerHTML = Tee(
-          "<div class=cd><span class=pfx>{prefix}</span>{code}</div>{lit}<div class=product>{prod}</div><div class=addr>{name}</div><div class=comment>{comment}</div>",
-          code,
-        );
-        let cls = "code-unused";
-        if (code.used) cls = "code-used";
-        else if (code.localUsed) cls = "code-localused";
-        document.body.className = cls;
+        const statusDiv = $("#status");
+        if (code) {
+          currentlyShownId = code.id;
+          statusDiv.innerHTML = Tee(
+            "<div class=cd><span class=pfx>{prefix}</span>{code}</div>{lit}<div class=product>{prod}</div><div class=addr>{name}</div><div class=comment>{comment}</div>",
+            code,
+          );
+          let cls = "code-unused";
+          if (code.used) cls = "code-used";
+          else if (code.localUsed) cls = "code-localused";
+          document.body.className = cls;
+        } else {
+          currentlyShownId = null;
+          statusDiv.innerHTML = "";
+          document.body.className = "";
+        }
       }
 
       /**
@@ -112,9 +119,14 @@
         }, 250);
       }
 
-      function search(enter) {
-        let nStarting = 0;
-        const inputCode = $("#code").value.toLowerCase();
+      /**
+       * Find matching codes for the given input code.
+       *
+       * @param {string} inputCode
+       * @returns {nMatches: number, code: Code | null}
+       */
+      function findMatchingCodes(inputCode) {
+        let nMatches = 0;
         let regexpText = `^${inputCode}`;
         if (/^[-a-z]+ /i.test(inputCode)) {
           // Cheap "fuzzy" searching ("d bu" will match "desu butler")
@@ -126,7 +138,6 @@
         }
         const searchRegexp = new RegExp(regexpText, "i");
         let lastCode = null;
-        document.body.className = "";
         for (const code of Object.values(codes)) {
           const prefixedCode = (code.prefix || "") + code.code;
           if (
@@ -137,23 +148,32 @@
             searchRegexp.test(prefixedCode) ||
             searchRegexp.test(code.lit)
           ) {
-            nStarting++;
+            nMatches++;
             lastCode = code;
           }
         }
-        const statusDiv = $("#status");
-        if (nStarting === 1) {
-          showCode(lastCode);
-          if (enter) confirmUseCode(lastCode);
-        } else if (nStarting === 0) {
-          statusDiv.innerHTML = "Koodilla ei löydy yhtään lippua. Ole hyvä ja tarkista oikeinkirjoitus ja tapahtuma!";
-        } else {
-          statusDiv.innerHTML = `... ${nStarting} ...`;
-        }
+        return { nMatches, code: nMatches === 1 ? lastCode : null };
       }
 
-      function keyPress() {
-        search(false);
+      function search(enter) {
+        const statusDiv = $("#status");
+        const inputCode = $("#code").value.toLowerCase().trim();
+        if (!inputCode.length) {
+          showCode(null);
+          statusDiv.innerHTML = "";
+          return;
+        }
+        const { nMatches, code } = findMatchingCodes(inputCode);
+        if (nMatches === 1) {
+          showCode(code);
+          if (enter) confirmUseCode(code);
+        } else if (nMatches === 0) {
+          showCode(null);
+          statusDiv.innerHTML = "Koodilla ei löydy yhtään lippua. Ole hyvä ja tarkista oikeinkirjoitus ja tapahtuma!";
+        } else {
+          showCode(null);
+          statusDiv.innerHTML = `... ${nMatches} ...`;
+        }
       }
 
       function formSubmit(event) {
@@ -200,9 +220,8 @@
         await download();
         setInterval(download, (50 + Math.random() * 20) * 1000);
         setInterval(syncUseQueue, 5000);
-
-        $("#code").addEventListener("input", keyPress, true);
-        document.getElementById("codeform").addEventListener("submit", debounce(formSubmit, 250), true);
+        $("#code").addEventListener("input", () => search(false), true);
+        $("#codeform").addEventListener("submit", debounce(formSubmit, 250), true);
       };
     </script>
     <style>

--- a/lippukala/templates/lippukala/pos.html
+++ b/lippukala/templates/lippukala/pos.html
@@ -21,6 +21,9 @@
        * @property {Code[]} codes
        */
 
+      /** @type {Code|null} */
+      let codeToConfirm = null;
+
       /** @type {Record<number, Code>} */
       const codes = {};
 
@@ -106,10 +109,22 @@
         if (code.used || code.localUsed) {
           alert("Koodi näyttää jo käytetyltä!\nOta yhteys tapahtuman taloustiimiin asian selvittämiseksi.");
           return;
-        } // eslint-disable-next-line no-restricted-globals
-        if (!confirm(`Käytä koodi ${code.code}?`)) {
+        }
+        codeToConfirm = code;
+        $("#confirm-dialog").showModal();
+        $("#confirm-button").focus();
+      }
+
+      /**
+       * Form submit handler for the confirm form dialog.
+       */
+      function onConfirmCode() {
+        const code = codeToConfirm;
+        if (!code) {
+          alert("Koodi puuttuu, kummaa!");
           return;
         }
+        codeToConfirm = null;
         useCode(code);
         setTimeout(syncUseQueue, 4);
         setTimeout(() => {
@@ -181,6 +196,12 @@
         search(true);
       }
 
+      function cancelConfirm() {
+        const confirmDialog = $("#confirm-dialog");
+        if (confirmDialog.open) confirmDialog.close();
+        $("#code").focus();
+      }
+
       async function syncUseQueue() {
         useQueue = useQueue.filter((id) => codes[id].localUsed && !codes[id].used);
         if (!useQueue.length) {
@@ -222,15 +243,30 @@
         setInterval(syncUseQueue, 5000);
         $("#code").addEventListener("input", () => search(false), true);
         $("#codeform").addEventListener("submit", debounce(formSubmit, 250), true);
+        $("#confirm-form").addEventListener("submit", onConfirmCode, true);
+        $("#confirm-dialog").addEventListener("close", cancelConfirm, true);
       };
     </script>
     <style>
-      body,
-      input {
+      html {
         font:
-          36pt/1.2 Arial,
+          36pt/1.2 system-ui,
           sans-serif;
-        -webkit-transition: background 0.5s;
+      }
+
+      body {
+        overflow: hidden;
+        transition: background 0.5s;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body,
+      input,
+      button {
+        font: inherit;
       }
 
       body.code-unused {
@@ -252,6 +288,7 @@
         color: #fff;
         font-size: 48pt;
         padding: 12pt;
+        margin-bottom: 0.5rem;
       }
 
       .pfx {
@@ -259,20 +296,57 @@
       }
 
       .product {
-        margin: 0.5em;
-        padding: 0.5em;
-        background: #333;
+        margin: 0.5rem 0;
+        padding: 0.5rem;
+        background: rgb(0, 0, 0, 0.4);
         color: #fff;
-        border: 0.2em solid #000;
       }
 
-      form {
+      #codeform {
         margin: auto;
         text-align: center;
       }
 
       #code {
         width: 100%;
+        margin-bottom: 0.5rem;
+        padding: 0.25rem;
+      }
+
+      ::backdrop {
+        background-image: linear-gradient(to bottom, rgb(0, 0, 0, 0.8), rgb(0, 0, 0, 0.4), rgb(0, 0, 0, 0.8));
+      }
+
+      #confirm-dialog {
+        min-width: 15em;
+        backdrop-filter: blur(5px);
+        background: rgba(255, 255, 255, 0.85);
+        text-align: center;
+        font-size: 0.75em;
+        padding: 0.5rem;
+      }
+
+      #confirm-dialog form {
+        display: inline;
+      }
+
+      #confirm-dialog button {
+        margin: 0.5em;
+        margin-bottom: 0;
+        padding: 0.25em 0.75em;
+        border-width: 0;
+        border-bottom-width: 0.1em;
+      }
+
+      #confirm-button {
+        background: lightgreen;
+        border-bottom-color: forestgreen;
+        font-weight: bold;
+      }
+
+      #cancel-button {
+        background: orangered;
+        border-bottom-color: firebrick;
       }
     </style>
   </head>
@@ -281,5 +355,14 @@
       <input placeholder="koodi tähän" type="text" id="code" autofocus autocomplete="no" /><br />
       <div id="status">&nbsp;</div>
     </form>
+    <dialog id="confirm-dialog">
+      Käytä koodi?
+      <div>
+        <form method="dialog" id="confirm-form">
+          <button id="confirm-button">Käytä</button>
+        </form>
+        <button id="cancel-button" onclick="cancelConfirm()">Peruuta</button>
+      </div>
+    </dialog>
   </body>
 </html>

--- a/lippukala/templates/lippukala/pos.html
+++ b/lippukala/templates/lippukala/pos.html
@@ -58,9 +58,7 @@
       }
 
       function Tee(template, env) {
-        return template.replace(/\{(.+?)\}/g, (_, m) =>
-          escapeHtml(env[m] || "").replace(/\n/g, "<br>"),
-        );
+        return template.replace(/\{(.+?)\}/g, (_, m) => escapeHtml(env[m] || "").replace(/\n/g, "<br>"));
       }
 
       /**
@@ -92,9 +90,7 @@
        */
       function confirmUseCode(code) {
         if (code.used || code.localUsed) {
-          alert(
-            "Koodi näyttää jo käytetyltä!\nOta yhteys tapahtuman taloustiimiin asian selvittämiseksi.",
-          );
+          alert("Koodi näyttää jo käytetyltä!\nOta yhteys tapahtuman taloustiimiin asian selvittämiseksi.");
           return;
         } // eslint-disable-next-line no-restricted-globals
         if (!confirm(`Käytä koodi ${code.code}?`)) {
@@ -141,8 +137,7 @@
           showCode(lastCode);
           if (enter) confirmUseCode(lastCode);
         } else if (nStarting === 0) {
-          statusDiv.innerHTML =
-            "Koodilla ei löydy yhtään lippua. Ole hyvä ja tarkista oikeinkirjoitus ja tapahtuma!";
+          statusDiv.innerHTML = "Koodilla ei löydy yhtään lippua. Ole hyvä ja tarkista oikeinkirjoitus ja tapahtuma!";
         } else {
           statusDiv.innerHTML = `... ${nStarting} ...`;
         }
@@ -158,9 +153,7 @@
       }
 
       async function syncUseQueue() {
-        useQueue = useQueue.filter(
-          (id) => codes[id].localUsed && !codes[id].used,
-        );
+        useQueue = useQueue.filter((id) => codes[id].localUsed && !codes[id].used);
         if (!useQueue.length) {
           return;
         }
@@ -202,9 +195,7 @@
         codeInput = document.getElementById("code");
         statusDiv = document.getElementById("status");
         codeInput.addEventListener("input", keyPress, true);
-        document
-          .getElementById("codeform")
-          .addEventListener("submit", debounce(formSubmit, 250), true);
+        document.getElementById("codeform").addEventListener("submit", debounce(formSubmit, 250), true);
       };
     </script>
     <style>
@@ -261,13 +252,7 @@
   </head>
   <body onload="init()">
     <form id="codeform">
-      <input
-        placeholder="koodi tähän"
-        type="text"
-        id="code"
-        autofocus
-        autocomplete="no"
-      /><br />
+      <input placeholder="koodi tähän" type="text" id="code" autofocus autocomplete="no" /><br />
       <div id="status">&nbsp;</div>
     </form>
   </body>

--- a/lippukala/templates/lippukala/pos.html
+++ b/lippukala/templates/lippukala/pos.html
@@ -21,9 +21,6 @@
        * @property {Code[]} codes
        */
 
-      let codeInput;
-      let statusDiv;
-
       /** @type {Record<number, Code>} */
       const codes = {};
 
@@ -32,6 +29,16 @@
 
       /** @type {number|null} */
       let currentlyShownId = null;
+
+      /**
+       * @param {string} id ID or selector
+       * @returns {HTMLElement}
+       */
+      function $(id) {
+        const el = document.getElementById(id) ?? document.querySelector(id);
+        if (!el) throw new Error(`Element ${id} not found`);
+        return el;
+      }
 
       /**
        * @param {CodesResponse} data
@@ -66,7 +73,7 @@
        */
       function showCode(code) {
         currentlyShownId = code.id;
-        statusDiv.innerHTML = Tee(
+        $("#status").innerHTML = Tee(
           "<div class=cd><span class=pfx>{prefix}</span>{code}</div>{lit}<div class=product>{prod}</div><div class=addr>{name}</div><div class=comment>{comment}</div>",
           code,
         );
@@ -99,6 +106,7 @@
         useCode(code);
         setTimeout(syncUseQueue, 4);
         setTimeout(() => {
+          const codeInput = $("#code");
           codeInput.value = "";
           codeInput.focus();
         }, 250);
@@ -106,7 +114,7 @@
 
       function search(enter) {
         let nStarting = 0;
-        const inputCode = codeInput.value.toLowerCase();
+        const inputCode = $("#code").value.toLowerCase();
         let regexpText = `^${inputCode}`;
         if (/^[-a-z]+ /i.test(inputCode)) {
           // Cheap "fuzzy" searching ("d bu" will match "desu butler")
@@ -133,6 +141,7 @@
             lastCode = code;
           }
         }
+        const statusDiv = $("#status");
         if (nStarting === 1) {
           showCode(lastCode);
           if (enter) confirmUseCode(lastCode);
@@ -192,9 +201,7 @@
         setInterval(download, (50 + Math.random() * 20) * 1000);
         setInterval(syncUseQueue, 5000);
 
-        codeInput = document.getElementById("code");
-        statusDiv = document.getElementById("status");
-        codeInput.addEventListener("input", keyPress, true);
+        $("#code").addEventListener("input", keyPress, true);
         document.getElementById("codeform").addEventListener("submit", debounce(formSubmit, 250), true);
       };
     </script>

--- a/lippukala/templates/lippukala/pos.html
+++ b/lippukala/templates/lippukala/pos.html
@@ -67,6 +67,14 @@
         return div.innerHTML;
       }
 
+      function shortenName(name) {
+        if (name) {
+          const [word1, word2] = name.trim().split(/\s+/);
+          return `${word1} ${word2[0]}.`;
+        }
+        return "";
+      }
+
       function Tee(template, env) {
         return template.replace(/\{(.+?)\}/g, (_, m) => escapeHtml(env[m] || "").replace(/\n/g, "<br>"));
       }
@@ -79,8 +87,8 @@
         if (code) {
           currentlyShownId = code.id;
           statusDiv.innerHTML = Tee(
-            "<div class=cd><span class=pfx>{prefix}</span>{code}</div>{lit}<div class=product>{prod}</div><div class=addr>{name}</div><div class=comment>{comment}</div>",
-            code,
+            "<div class=cd><span class=pfx>{prefix}</span>{code}</div>{lit}<div class=product>{prod}</div><div class=addr>{short_name}<div class=fulladdr>{name}</div></div><div class=comment>{comment}</div>",
+            { ...code, short_name: shortenName(code.name) },
           );
           let cls = "code-unused";
           if (code.used) cls = "code-used";
@@ -300,6 +308,18 @@
         padding: 0.5rem;
         background: rgb(0, 0, 0, 0.4);
         color: #fff;
+      }
+
+      .fulladdr {
+        font-size: 75%;
+        margin-top: 0.5em;
+        color: transparent;
+        border: 1px dashed rgb(255, 255, 255, 0.5);
+      }
+
+      .fulladdr:hover {
+        color: inherit;
+        border-color: transparent;
       }
 
       #codeform {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "prettier": {
-    "trailingComma": "all"
+    "trailingComma": "all",
+    "printWidth": 120
   },
   "devDependencies": {
     "eslint": "^8.56.0",


### PR DESCRIPTION
Instead of an old busted `confirm()`, let's do [`<dialog>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog)!

Also makes the POS view a bit more GDPR-y by hiding the full name information by default.

Fixes #3, a mere 7 years after reporting.

![a](https://github.com/kcsry/lippukala/assets/58669/80e39afd-033f-4339-93cd-9d0a0837385b)
