### PR TITLE
POS improvements

### DIFF
--- a/lippukala/static/lippukala/pos.css
+++ b/lippukala/static/lippukala/pos.css
@@ -71,6 +71,12 @@ body.code-used-here .statustext {
   color: #fff;
 }
 
+.check-year .product {
+  background: rgb(255, 255, 0, 0.8);
+  color: #000;
+  animation: blink 0.7s infinite;
+}
+
 .fulladdr {
   font-size: 75%;
   margin-top: 0.5em;

--- a/lippukala/static/lippukala/pos.css
+++ b/lippukala/static/lippukala/pos.css
@@ -1,12 +1,13 @@
 html {
   font:
-    36pt/1.2 system-ui,
+    32pt/1.2 system-ui,
     sans-serif;
 }
 
 body {
   overflow: hidden;
   transition: background 0.5s;
+  margin: 0;
 }
 
 * {
@@ -69,10 +70,11 @@ body.code-used {
   text-align: center;
 }
 
-#code {
+input#code {
   width: 100%;
   margin-bottom: 0.5rem;
   padding: 0.25rem;
+  border: none;
 }
 
 ::backdrop {

--- a/lippukala/static/lippukala/pos.css
+++ b/lippukala/static/lippukala/pos.css
@@ -110,3 +110,24 @@ body.code-used {
   background: orangered;
   border-bottom-color: firebrick;
 }
+
+textarea#log {
+  position: absolute;
+  right: 5px;
+  bottom: 5px;
+  min-width: 30em;
+  height: 15em;
+  background: transparent;
+  border: none;
+  padding: 0;
+  font-size: 8pt;
+  opacity: 0.3;
+  transition:
+    height 0.2s,
+    opacity 0.2s;
+}
+
+textarea#log:hover {
+  opacity: 1;
+  height: 25em;
+}

--- a/lippukala/static/lippukala/pos.css
+++ b/lippukala/static/lippukala/pos.css
@@ -24,13 +24,31 @@ body.code-unused {
   background: #00c300;
 }
 
-body.code-localused {
+body.code-used-not-synced {
   background: #f95;
+}
+
+body.code-used-here {
+  background: cornflowerblue;
 }
 
 body.code-used {
   background: #e51e1f;
   color: yellow;
+}
+
+.statustext {
+  font-weight: bold;
+  transition: color 1s;
+  margin-bottom: 0.5em;
+}
+
+body.code-used .statustext {
+  animation: blink 1s infinite;
+}
+
+body.code-used-here .statustext {
+  color: #fff;
 }
 
 .cd {
@@ -132,4 +150,19 @@ textarea#log {
 textarea#log:hover {
   opacity: 1;
   height: 25em;
+}
+
+@keyframes blink {
+  0% {
+    opacity: 0;
+  }
+  50% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
 }

--- a/lippukala/static/lippukala/pos.js
+++ b/lippukala/static/lippukala/pos.js
@@ -38,6 +38,14 @@ function $(id) {
   return el;
 }
 
+function addLogEntry(string) {
+  const time = new Date().toLocaleTimeString("fi-FI");
+  const messageWithTime = `${time}: ${string}\n`;
+  const logTextArea = $("log");
+  logTextArea.value += messageWithTime;
+  logTextArea.scroll(0, 90000);
+}
+
 /**
  * @param {CodesResponse} data
  */
@@ -45,7 +53,6 @@ function parseData(data) {
   for (const code of data.codes) {
     codes[code.id] = { ...(codes[code.id] || {}), ...code };
   }
-  console.log(`Got ${data.codes.length} codes`);
 }
 
 async function download() {
@@ -217,9 +224,12 @@ async function syncUseQueue() {
     method: "POST",
     body: formData,
   });
-  if (!resp.ok) throw new Error(`Failed to sync use queue`);
+  if (!resp.ok) {
+    addLogEntry("Koodien synkronointi epäonnistui");
+    throw new Error(`Failed to sync use queue`);
+  }
   const data = await resp.json();
-  console.log(`successfully synced ${useQueue.length} code uses`);
+  addLogEntry(`Käytettiin ${useQueue.length} koodia`);
   parseData(data);
   if (currentlyShownId) showCode(codes[currentlyShownId]);
 }
@@ -242,6 +252,7 @@ function debounce(fn, delay) {
 
 window.init = async function init() {
   await download();
+  addLogEntry(`${Object.keys(codes).length} koodia`);
   setInterval(download, (50 + Math.random() * 20) * 1000);
   setInterval(syncUseQueue, 5000);
   $("#code").addEventListener("input", () => search(false), true);

--- a/lippukala/static/lippukala/pos.js
+++ b/lippukala/static/lippukala/pos.js
@@ -35,6 +35,9 @@ let useQueue = [];
 /** @type {number|null} */
 let currentlyShownId = null;
 
+/** The current year, as a string. */
+const thisYearString = String(new Date().getFullYear());
+
 /**
  * @param {string} id ID or selector
  * @returns {HTMLElement}
@@ -115,6 +118,15 @@ function getCodeStatusText(code) {
 }
 
 /**
+ * Return if the code seems to be for a product that is not for this year.
+ * @param code {Code}
+ */
+function isPossiblyOldCode(code) {
+  const yearMatch = /\b(20\d{2})\b/g.exec(code.prod);
+  return yearMatch && yearMatch[1] !== thisYearString;
+}
+
+/**
  * @param {Code|null} code
  */
 function showCode(code) {
@@ -125,6 +137,7 @@ function showCode(code) {
       "<div class=cd><span class=pfx>{prefix}</span>{code}</div>{lit}<div class=product>{prod}</div><div class=statustext>{statusText}</div></div><div class=addr>{short_name}<div class=fulladdr>{name}</div></div><div class=comment>{comment}</div>",
       { ...code, short_name: shortenName(code.name), statusText: getCodeStatusText(code) },
     );
+    statusDiv.classList.toggle("check-year", isPossiblyOldCode(code));
     document.body.className = getCodeCSSClass(code);
   } else {
     currentlyShownId = null;

--- a/lippukala/static/lippukala/pos.js
+++ b/lippukala/static/lippukala/pos.js
@@ -1,14 +1,14 @@
 /**
  * @typedef {Object} Code
- * @property {number} id
  * @property {boolean} used
- * @property {string} code
- * @property {string} prefix
- * @property {string} lit
+ * @property {string|null} used_ts
+ * @property {number} id
  * @property {string} [name]
+ * @property {string} code
  * @property {string} comment
+ * @property {string} lit
+ * @property {string} prefix
  * @property {string} prod
- * @property {boolean} [localUsed]
  */
 
 /**
@@ -21,6 +21,13 @@ let codeToConfirm = null;
 
 /** @type {Record<number, Code>} */
 const codes = {};
+
+/**
+ * A set of all code IDs used locally (not persistent
+ * between reloads)
+ * @type {Set<number>}
+ */
+const codeIdsUsedLocally = new Set();
 
 /** @type {number[]} */
 let useQueue = [];
@@ -82,6 +89,32 @@ function Tee(template, env) {
 }
 
 /**
+ * @param code {Code}
+ */
+function isCodeLocallyUsed(code) {
+  return codeIdsUsedLocally.has(code.id);
+}
+
+function getCodeCSSClass(code) {
+  const isLocallyUsed = isCodeLocallyUsed(code);
+  if (code.used) {
+    return isLocallyUsed ? "code-used-here" : "code-used";
+  }
+  return isLocallyUsed ? "code-used-not-synced" : "code-unused";
+}
+
+function getCodeStatusText(code) {
+  const prettierTime = code.used_ts ? code.used_ts.replace(/T/, "\u2009") : "";
+  if (isCodeLocallyUsed(code)) {
+    return `Käytetty tässä ${prettierTime}`;
+  }
+  if (code.used) {
+    return `Käytetty ${prettierTime}`;
+  }
+  return "Ei käytetty";
+}
+
+/**
  * @param {Code|null} code
  */
 function showCode(code) {
@@ -89,13 +122,10 @@ function showCode(code) {
   if (code) {
     currentlyShownId = code.id;
     statusDiv.innerHTML = Tee(
-      "<div class=cd><span class=pfx>{prefix}</span>{code}</div>{lit}<div class=product>{prod}</div><div class=addr>{short_name}<div class=fulladdr>{name}</div></div><div class=comment>{comment}</div>",
-      { ...code, short_name: shortenName(code.name) },
+      "<div class=cd><span class=pfx>{prefix}</span>{code}</div>{lit}<div class=product>{prod}</div><div class=statustext>{statusText}</div></div><div class=addr>{short_name}<div class=fulladdr>{name}</div></div><div class=comment>{comment}</div>",
+      { ...code, short_name: shortenName(code.name), statusText: getCodeStatusText(code) },
     );
-    let cls = "code-unused";
-    if (code.used) cls = "code-used";
-    else if (code.localUsed) cls = "code-localused";
-    document.body.className = cls;
+    document.body.className = getCodeCSSClass(code);
   } else {
     currentlyShownId = null;
     statusDiv.innerHTML = "";
@@ -107,7 +137,7 @@ function showCode(code) {
  * @param {Code} code
  */
 function useCode(code) {
-  code.localUsed = true;
+  codeIdsUsedLocally.add(code.id);
   useQueue.push(code.id);
   showCode(code);
 }
@@ -213,7 +243,7 @@ function cancelConfirm() {
 }
 
 async function syncUseQueue() {
-  useQueue = useQueue.filter((id) => codes[id].localUsed && !codes[id].used);
+  useQueue = useQueue.filter((id) => isCodeLocallyUsed(codes[id]) && !codes[id].used);
   if (!useQueue.length) {
     return;
   }

--- a/lippukala/templates/lippukala/pos.html
+++ b/lippukala/templates/lippukala/pos.html
@@ -19,5 +19,6 @@
         <button id="cancel-button" onclick="cancelConfirm()">Peruuta</button>
       </div>
     </dialog>
+    <textarea id="log" readonly></textarea>
   </body>
 </html>

--- a/lippukala/views.py
+++ b/lippukala/views.py
@@ -8,16 +8,17 @@ from lippukala.excs import CantUseException
 from lippukala.models import Code
 
 
-def serialize_code(code):
+def serialize_code(code: Code) -> dict:
     return {
-        "id": code.id,
-        "used": bool(code.used_at),
         "code": code.code,
-        "prefix": code.prefix,
+        "comment": code.order.comment,
+        "id": code.id,
         "lit": code.literate_code,
         "name": code.order.address_text,
-        "comment": code.order.comment,
+        "prefix": code.prefix,
         "prod": code.product_text,
+        "used": code.is_used,
+        "used_ts": code.used_on.isoformat(timespec="minutes") if code.used_on else None,
     }
 
 


### PR DESCRIPTION
This PR improves the POS view in a couple of ways:

* there's now a small, translucent event log view in the corner of the screen, allowing a suitably technical ylikuutti or similar to try and debug things
  * fixes #17 
* the screen becomes baby blue instead of red when codes are marked used (and synced as such) on the same station; IOW, if you hit enter too early, you don't need to wonder whether the code was actually used elsewhere and it's red for that reason, or if you just used it right there and then
* the code's status (including date-of-use) is now visible, and will blink to capture attention if the code is already used
* if the product name for the code seems to be for another year's event (IOW, if we find a year-like string in the name and it's not today's year), it's highlighted and will blink.

... and minor æsthetics improvements.

## highlight for wrong year

<img alt="bsb" src="https://github.com/kcsry/lippukala/assets/58669/9b6a7832-0a11-4763-a244-6e7a0b16c1d0">

## used here

<img  alt="a1" src="https://github.com/kcsry/lippukala/assets/58669/55d51f81-910c-4bee-8ad7-5a0486d9fa11">
