### PR TITLE
Admin improvements

### DIFF
--- a/lippukala/admin.py
+++ b/lippukala/admin.py
@@ -1,6 +1,7 @@
 from django.contrib.admin import site
 from django.contrib.admin.options import ModelAdmin, TabularInline
 
+from lippukala.consts import UNUSED
 from lippukala.models import Code, Order
 
 
@@ -50,6 +51,12 @@ class CodeAdmin(ModelAdmin):
 
     def has_add_permission(self, request):
         return False
+
+    def save_model(self, request, obj: Code, form, change):
+        if obj.status == UNUSED:
+            obj.used_at = ""
+            obj.used_on = None
+        super().save_model(request, obj, form, change)
 
 
 site.register(Order, OrderAdmin)


### PR DESCRIPTION
This PR improves the Lippukala admin a bit:

* when setting a code to be unused, the other fields that need to be unset so as to avoid Un-sane Situation errors are automatically unset
* status/used-at/used-by changes will now have their old and new values saved in the Django admin log. Reading them from there will require shell access though, since the Django admin does not know how to read a `"lippukala"` record.